### PR TITLE
fix inconsistent return results

### DIFF
--- a/R/sf_helpers.R
+++ b/R/sf_helpers.R
@@ -107,9 +107,9 @@ sf_coordinates = \(sfj){
 
   coords = sfj %>%
     sf::st_coordinates() %>%
-    {.[,c('X','Y')]}
+    {.[,c('X','Y'),drop = FALSE]}
 
-  return(as.matrix(coords))
+  return(coords)
 }
 
 #' @title generates distance matrix


### PR DESCRIPTION
Fixed the issue in `sf_coordinate` where automatic dimension dropping of generalized vectors led to inconsistent return values.
