### PR TITLE
correct maintainer surname spelling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,12 +2,12 @@ Package: sdsfun
 Title: Spatial Data Science Complementary Features
 Version: 0.9.0
 Authors@R: 
-    person(given = "Wenbo", family = "Lv",
+    person(given = "Wenbo", family = "Lyu",
            email = "lyu.geosocial@gmail.com", 
            role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0002-6003-3800"))
 Description: Wrapping and supplementing commonly used functions in the R ecosystem related to spatial data science, 
-             while serving as a basis for other packages maintained by Wenbo Lv.
+             while serving as a basis for other packages maintained by Wenbo Lyu.
 License: GPL-3
 Encoding: UTF-8
 URL: https://stscl.github.io/sdsfun/, https://github.com/stscl/sdsfun

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -10,7 +10,7 @@ home:
   title: |
     sdsfun | Spatial Data Science Complementary Features
 authors:
-  Wenbo Lv:
+  Wenbo Lyu:
     href: https://spatlyu.github.io/
 
 reference:

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,10 @@
+citHeader("To cite package sdsfun in publications, please use:")
+
+bibentry(
+  bibtype  = "Manual",
+  title    = "{sdsfun: Spatial Data Science Complementary Features}",
+  author   = "Wenbo Lyu",
+  year     = "2026",
+  note     = "R package version 0.9.0",
+  doi      = "10.32614/CRAN.package.sdsfun"
+)


### PR DESCRIPTION
This PR updates the maintainer name from `Wenbo Lv` to `Wenbo Lyu` to align with my official passport spelling.

## Background

- **Chinese name**: 吕文博
- **Previous English name**: Wenbo Lv
- **Passport spelling**: Wenbo Lyu

The spelling `Lyu` is the standardized ASCII representation of the surname "吕" (Lü) used in official Chinese documents, including passports. This change ensures consistency across all official and academic records.

## Changes

- Updated maintainer name in `DESCRIPTION` file
- Updated author information in package metadata